### PR TITLE
Ignore trailing characters in the token file

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 		"$HOME/.local/share",
 	), "token")
 
-	token := utils.ReadFile(tokenLocation, true)[:32]
+	token := utils.ReadToken(tokenLocation)
 
 	cfg := config.GetConfiguration(args.AlternateConfigFile)
 	api := apiengine.New(token, cfg.ApiUrl, cfg.CaseInsensitiveFields)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,8 @@ func main() {
 		"$HOME/.local/share",
 	), "token")
 
-	token := utils.ReadFile(tokenLocation, true)
+	token := utils.ReadFile(tokenLocation, true)[:32]
+
 	cfg := config.GetConfiguration(args.AlternateConfigFile)
 	api := apiengine.New(token, cfg.ApiUrl, cfg.CaseInsensitiveFields)
 

--- a/utils/files.go
+++ b/utils/files.go
@@ -18,3 +18,15 @@ func ReadFile(file string, allowNonexistent bool) string {
 	Check(err)
 	return string(bytes)
 }
+
+func ReadToken(filename string) string {
+	file, err := os.Open(filename)
+	Check(err)
+	defer file.Close()
+
+	tokenBytes := make([]byte, 32)
+	_, err = file.Read(tokenBytes)
+	Check(err)
+
+	return string(tokenBytes)
+}


### PR DESCRIPTION
This PR fixes something annoying. It is a very primitive solution.

Previously if the token file ended in a newline (which is pretty much
the standard) the code would not work.

This commit just truncates the token to the length of 32 characters
which is the standard token length.